### PR TITLE
Add consolidated edge function to halve invocation costs

### DIFF
--- a/supabase/functions/cerefox/embeddings.ts
+++ b/supabase/functions/cerefox/embeddings.ts
@@ -1,0 +1,81 @@
+export const OPENAI_EMBEDDING_URL = "https://api.openai.com/v1/embeddings";
+export const OPENAI_MODEL = "text-embedding-3-small";
+export const EMBEDDING_DIMENSIONS = 768;
+
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 500; // 500ms, 1s, 2s exponential backoff
+
+/**
+ * Embed one or more texts via the OpenAI API.
+ * Always returns an array of embeddings (one per input text).
+ * Retries 5xx and network errors up to 3 times with exponential backoff.
+ */
+export async function embedTexts(
+  input: string | string[],
+  apiKey: string,
+): Promise<number[][]> {
+  let lastError: Error | null = null;
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(OPENAI_EMBEDDING_URL, {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: OPENAI_MODEL,
+          input,
+          dimensions: EMBEDDING_DIMENSIONS,
+        }),
+      });
+
+      if (!response.ok) {
+        const err = await response.text();
+        // Don't retry client errors (4xx)
+        if (response.status < 500) {
+          throw new Error(`OpenAI embedding error ${response.status}: ${err}`);
+        }
+        // Server errors (5xx) are retryable
+        lastError = new Error(
+          `OpenAI embedding error ${response.status}: ${err}`,
+        );
+        const backoff = INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+        console.warn(
+          `Embedding API returned ${response.status} (attempt ${attempt + 1}/${MAX_RETRIES}), retrying in ${backoff}ms`,
+        );
+        await new Promise((r) => setTimeout(r, backoff));
+        continue;
+      }
+
+      const data = await response.json();
+      if (attempt > 0) {
+        console.info(`Embedding API succeeded on retry ${attempt}`);
+      }
+      const sorted = data.data.sort(
+        (a: { index: number }, b: { index: number }) => a.index - b.index,
+      );
+      return sorted.map((d: { embedding: number[] }) => d.embedding);
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        err.message.startsWith("OpenAI embedding error")
+      ) {
+        // Non-retryable (4xx) errors already thrown above
+        throw err;
+      }
+      // Network/timeout errors are retryable
+      lastError = err instanceof Error ? err : new Error(String(err));
+      const backoff = INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+      console.warn(
+        `Embedding API request failed: ${lastError.message} (attempt ${attempt + 1}/${MAX_RETRIES}), retrying in ${backoff}ms`,
+      );
+      await new Promise((r) => setTimeout(r, backoff));
+    }
+  }
+
+  throw (
+    lastError ?? new Error(`Embedding API failed after ${MAX_RETRIES} attempts`)
+  );
+}

--- a/supabase/functions/cerefox/index.ts
+++ b/supabase/functions/cerefox/index.ts
@@ -1,0 +1,525 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+
+import {
+  CORS_HEADERS,
+  createServiceClient,
+  errorResponse,
+  getOpenAIKey,
+  jsonResponse,
+  notificationResponse,
+} from "./shared.ts";
+import { executeSearch } from "./tools/search.ts";
+import { executeIngest } from "./tools/ingest.ts";
+import { executeGetDocument } from "./tools/get-document.ts";
+import { executeListVersions } from "./tools/list-versions.ts";
+import { executeAuditLog } from "./tools/audit-log.ts";
+import { executeMetadata } from "./tools/metadata.ts";
+
+/**
+ * cerefox — Consolidated Supabase Edge Function
+ *
+ * MCP Streamable HTTP server (spec 2025-03-26). All business logic runs
+ * inline — no internal fetch() delegation to other edge functions.
+ * One MCP call = one edge function invocation.
+ *
+ * This is a consolidated version of cerefox-mcp that eliminates the
+ * gateway-to-worker hop that doubled Supabase invocation counts.
+ *
+ * Supported clients:
+ *   Claude Code    — claude mcp add --transport http cerefox <url> --header "Authorization: Bearer <anon-key>"
+ *   Cursor         — url + headers.Authorization in mcp.json
+ *   Claude Desktop — npx supergateway --streamableHttp <url> --header "Authorization: Bearer <anon-key>"
+ */
+
+const MCP_VERSION = "2025-03-26";
+const SERVER_NAME = "cerefox";
+const SERVER_VERSION = "0.2.0";
+
+// ── Tool definitions ────────────────────────────────────────────────────────
+
+const TOOLS = [
+  {
+    name: "cerefox_search",
+    description:
+      "Search the Cerefox personal knowledge base. Returns complete documents ranked by hybrid (FTS + semantic) relevance.",
+    inputSchema: {
+      type: "object",
+      required: ["query"],
+      properties: {
+        query: {
+          type: "string",
+          description: "Natural-language search query",
+        },
+        match_count: {
+          type: "integer",
+          description: "Maximum number of documents to return (default: 5)",
+        },
+        project_name: {
+          type: "string",
+          description:
+            "Filter results to a specific project by name (optional)",
+        },
+        metadata_filter: {
+          type: "object",
+          description:
+            'Optional JSONB containment filter. Only documents whose metadata contains ALL specified key-value pairs are returned. Example: {"type": "decision", "status": "active"}. Call cerefox_list_metadata_keys first to discover available keys and values. Omit to search all documents.',
+          additionalProperties: { type: "string" },
+        },
+        max_bytes: {
+          type: "integer",
+          description:
+            "Optional response size budget in bytes. Results are dropped whole until the budget is satisfied; a truncated flag is set when results are dropped. Defaults to the server maximum (200000). Pass a smaller value if your context window is limited. Values above the server maximum are silently capped.",
+        },
+      },
+    },
+  },
+  {
+    name: "cerefox_ingest",
+    description: "Save a note or document to the Cerefox knowledge base.",
+    inputSchema: {
+      type: "object",
+      required: ["title", "content"],
+      properties: {
+        title: {
+          type: "string",
+          description: "Document title",
+        },
+        content: {
+          type: "string",
+          description: "Markdown content",
+        },
+        project_name: {
+          type: "string",
+          description: "Project to assign to (created if absent, optional)",
+        },
+        source: {
+          type: "string",
+          description: 'Origin label (default: "agent")',
+        },
+        update_if_exists: {
+          type: "boolean",
+          description:
+            "When true, update an existing document with the same title instead of creating a new one (default: false)",
+        },
+        metadata: {
+          type: "object",
+          description: "Arbitrary JSON metadata (optional)",
+        },
+        author: {
+          type: "string",
+          description:
+            'Name of the agent or tool performing the ingestion (e.g., "Claude Code", "Cursor"). Recorded in the audit log for attribution. Defaults to "mcp-agent" if not provided.',
+        },
+      },
+    },
+  },
+  {
+    name: "cerefox_list_metadata_keys",
+    description:
+      "List all metadata keys currently in use across documents in the Cerefox knowledge base. Returns each key with its document count and up to 5 example values.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+    },
+  },
+  {
+    name: "cerefox_get_document",
+    description:
+      "Retrieve the full reconstructed content of a document. Pass version_id to retrieve an archived version; omit it (or pass null) for the current version. Version UUIDs are returned by cerefox_list_versions.",
+    inputSchema: {
+      type: "object",
+      required: ["document_id"],
+      properties: {
+        document_id: {
+          type: "string",
+          description: "UUID of the document to retrieve",
+        },
+        version_id: {
+          type: "string",
+          description:
+            "UUID of a specific archived version to retrieve (optional)",
+        },
+      },
+    },
+  },
+  {
+    name: "cerefox_list_versions",
+    description:
+      "List all archived versions of a document, newest first. Returns version_id (use with cerefox_get_document), version_number, source, chunk_count, total_chars, and created_at.",
+    inputSchema: {
+      type: "object",
+      required: ["document_id"],
+      properties: {
+        document_id: {
+          type: "string",
+          description:
+            "UUID of the document whose version history to list",
+        },
+      },
+    },
+  },
+  {
+    name: "cerefox_get_audit_log",
+    description:
+      "Retrieve audit log entries showing who changed what and when. Supports filtering by document, author, operation type, and time range. Returns entries with document titles, author attribution, size changes, and descriptions.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        document_id: {
+          type: "string",
+          description: "Filter by document UUID (optional)",
+        },
+        author: {
+          type: "string",
+          description: "Filter by author name (optional)",
+        },
+        operation: {
+          type: "string",
+          description:
+            "Filter by operation type: create, update-content, update-metadata, delete, status-change, archive, unarchive (optional)",
+        },
+        since: {
+          type: "string",
+          description:
+            "ISO timestamp lower bound for temporal queries (optional)",
+        },
+        limit: {
+          type: "integer",
+          description:
+            "Maximum number of entries to return (default: 50, max: 200)",
+        },
+      },
+    },
+  },
+];
+
+// ── Method handlers ──────────────────────────────────────────────────────────
+
+function handleInitialize(id: unknown): Response {
+  return jsonResponse({
+    jsonrpc: "2.0",
+    id,
+    result: {
+      protocolVersion: MCP_VERSION,
+      capabilities: {
+        tools: {},
+      },
+      serverInfo: {
+        name: SERVER_NAME,
+        version: SERVER_VERSION,
+      },
+    },
+  });
+}
+
+function handleToolsList(id: unknown): Response {
+  return jsonResponse({
+    jsonrpc: "2.0",
+    id,
+    result: { tools: TOOLS },
+  });
+}
+
+async function handleToolCall(
+  name: string,
+  args: Record<string, unknown>,
+): Promise<string> {
+  const supabase = createServiceClient();
+
+  if (name === "cerefox_search") {
+    const openaiKey = getOpenAIKey();
+    const result = await executeSearch(supabase, openaiKey, {
+      query: args.query as string,
+      match_count: (args.match_count as number) ?? 5,
+      project_name: args.project_name as string | undefined,
+      metadata_filter: (args.metadata_filter as Record<string, string>) ?? null,
+      ...(args.max_bytes != null ? { max_bytes: args.max_bytes as number } : {}),
+    });
+
+    if (result.results.length === 0) {
+      return "No results found.";
+    }
+
+    const rows = result.results as Array<{
+      document_id?: string;
+      doc_title?: string;
+      full_content?: string;
+      best_score?: number;
+      is_partial?: boolean;
+      chunk_count?: number;
+      total_chars?: number;
+    }>;
+
+    const parts: string[] = rows.map((row) => {
+      const title = row.doc_title ?? "Untitled";
+      const docId = row.document_id ? ` [id: ${row.document_id}]` : "";
+      const score =
+        row.best_score != null
+          ? ` (score: ${row.best_score.toFixed(3)})`
+          : "";
+      const partial = row.is_partial
+        ? ` -- partial (${row.chunk_count} of ${(row.total_chars ?? 0).toLocaleString()} chars)`
+        : "";
+      return `## ${title}${docId}${score}${partial}\n\n${row.full_content ?? ""}`;
+    });
+
+    let output = parts.join("\n\n---\n\n");
+
+    if (result.truncated) {
+      output += `\n\n[Results truncated at ${result.response_bytes} bytes. Use a more specific query or a smaller match_count to see more.]`;
+    }
+
+    return output;
+  }
+
+  if (name === "cerefox_ingest") {
+    const openaiKey = getOpenAIKey();
+    const result = await executeIngest(supabase, openaiKey, {
+      title: args.title as string,
+      content: args.content as string,
+      project_name: args.project_name as string | undefined,
+      source: (args.source as string) ?? "agent",
+      update_if_exists: (args.update_if_exists as boolean) ?? false,
+      metadata: (args.metadata as Record<string, unknown>) ?? {},
+      author: (args.author as string) ?? "mcp-agent",
+      author_type: "agent",
+    });
+
+    if (result.skipped) {
+      return `Document already up-to-date: "${result.title}" (id: ${result.document_id}). ${result.message ?? ""}`.trim();
+    }
+
+    if (result.updated) {
+      return `Document updated: "${result.title}" (id: ${result.document_id}), ${result.chunk_count} chunk(s), ${result.total_chars} chars.`;
+    }
+
+    const projectInfo = result.project_name
+      ? `, project: "${result.project_name}"`
+      : "";
+    return `Document saved: "${result.title}" (id: ${result.document_id}), ${result.chunk_count} chunk(s), ${result.total_chars} chars${projectInfo}.`;
+  }
+
+  if (name === "cerefox_list_metadata_keys") {
+    const keys = await executeMetadata(supabase);
+
+    if ((keys as unknown[]).length === 0) {
+      return "No metadata keys found across documents.";
+    }
+
+    return JSON.stringify(keys, null, 2);
+  }
+
+  if (name === "cerefox_get_document") {
+    try {
+      const result = await executeGetDocument(supabase, {
+        document_id: args.document_id as string,
+        version_id: (args.version_id as string) ?? null,
+      });
+
+      const label = result.is_archived
+        ? " (archived version)"
+        : " (current)";
+      return `# ${result.doc_title}${label}\n\n${result.full_content}`;
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        err.message === "DOCUMENT_NOT_FOUND"
+      ) {
+        return "Document not found.";
+      }
+      throw err;
+    }
+  }
+
+  if (name === "cerefox_list_versions") {
+    const versions = (await executeListVersions(supabase, {
+      document_id: args.document_id as string,
+    })) as Array<{
+      version_id: string;
+      version_number: number;
+      source: string;
+      chunk_count: number;
+      total_chars: number;
+      created_at: string;
+    }>;
+
+    if (!versions?.length) {
+      return "No archived versions found for this document.";
+    }
+
+    const lines = versions.map(
+      (v) =>
+        `v${v.version_number} | ${v.created_at.slice(0, 10)} | ${v.source} | ${v.chunk_count} chunks / ${v.total_chars.toLocaleString()} chars | id: ${v.version_id}`,
+    );
+    return `Archived versions (newest first):\n\n${lines.join("\n")}`;
+  }
+
+  if (name === "cerefox_get_audit_log") {
+    const entries = (await executeAuditLog(supabase, {
+      document_id: (args.document_id as string) ?? undefined,
+      author: (args.author as string) ?? undefined,
+      operation: (args.operation as string) ?? undefined,
+      since: (args.since as string) ?? undefined,
+      limit: (args.limit as number) ?? 50,
+    })) as Array<{
+      id: string;
+      document_id: string | null;
+      doc_title: string | null;
+      operation: string;
+      author: string;
+      author_type: string;
+      size_before: number | null;
+      size_after: number | null;
+      description: string;
+      created_at: string;
+    }>;
+
+    if (!entries?.length) return "No audit log entries found.";
+
+    const lines = entries.map((e) => {
+      const docLabel =
+        e.doc_title ??
+        (e.document_id ? e.document_id.slice(0, 8) + "..." : "(deleted)");
+      const sizeInfo =
+        e.size_before != null && e.size_after != null
+          ? ` | ${e.size_before} -> ${e.size_after} chars`
+          : e.size_after != null
+            ? ` | ${e.size_after} chars`
+            : "";
+      return `${e.created_at.slice(0, 19)} | ${e.operation} | ${e.author} (${e.author_type}) | ${docLabel}${sizeInfo} | ${e.description}`;
+    });
+
+    return `Audit log (${entries.length} entries, newest first):\n\n${lines.join("\n")}`;
+  }
+
+  throw new Error(`Unknown tool: ${name}`);
+}
+
+async function handleToolsCall(
+  id: unknown,
+  params:
+    | { name?: string; arguments?: Record<string, unknown> }
+    | undefined,
+): Promise<Response> {
+  const toolName = params?.name;
+  const args = params?.arguments ?? {};
+
+  if (!toolName) {
+    return errorResponse(id, -32602, "Invalid params: missing tool name");
+  }
+
+  const knownTools = [
+    "cerefox_search",
+    "cerefox_ingest",
+    "cerefox_list_metadata_keys",
+    "cerefox_get_document",
+    "cerefox_list_versions",
+    "cerefox_get_audit_log",
+  ];
+  if (!knownTools.includes(toolName)) {
+    return errorResponse(id, -32602, `Unknown tool: ${toolName}`);
+  }
+
+  try {
+    const text = await handleToolCall(toolName, args);
+    return jsonResponse({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        content: [{ type: "text", text }],
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return errorResponse(id, -32603, message);
+  }
+}
+
+// ── Main handler ─────────────────────────────────────────────────────────────
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  // CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { status: 200, headers: CORS_HEADERS });
+  }
+
+  // GET — health check for MCP clients that probe before connecting.
+  if (req.method === "GET") {
+    return jsonResponse({
+      name: SERVER_NAME,
+      version: SERVER_VERSION,
+      protocol: "mcp",
+      protocolVersion: MCP_VERSION,
+      status: "ok",
+    });
+  }
+
+  if (req.method !== "POST") {
+    return new Response("Method Not Allowed", {
+      status: 405,
+      headers: CORS_HEADERS,
+    });
+  }
+
+  // ── Parse JSON-RPC body ───────────────────────────────────────────────────
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return errorResponse(null, -32700, "Parse error: invalid JSON");
+  }
+
+  const { jsonrpc, id, method, params } = body as {
+    jsonrpc?: string;
+    id?: unknown;
+    method?: string;
+    params?: unknown;
+  };
+
+  if (jsonrpc !== "2.0") {
+    return errorResponse(
+      id ?? null,
+      -32600,
+      "Invalid Request: jsonrpc must be '2.0'",
+    );
+  }
+
+  if (!method) {
+    return errorResponse(
+      id ?? null,
+      -32600,
+      "Invalid Request: missing method",
+    );
+  }
+
+  // ── Method dispatch ───────────────────────────────────────────────────────
+  switch (method) {
+    case "initialize":
+      return handleInitialize(id);
+
+    case "initialized":
+    case "notifications/initialized":
+      return notificationResponse();
+
+    case "ping":
+      return jsonResponse({ jsonrpc: "2.0", id, result: {} });
+
+    case "tools/list":
+      return handleToolsList(id);
+
+    case "tools/call":
+      return await handleToolsCall(
+        id,
+        params as
+          | { name?: string; arguments?: Record<string, unknown> }
+          | undefined,
+      );
+
+    default:
+      return errorResponse(
+        id ?? null,
+        -32601,
+        `Method not found: ${method}`,
+      );
+  }
+});

--- a/supabase/functions/cerefox/shared.ts
+++ b/supabase/functions/cerefox/shared.ts
@@ -1,0 +1,50 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+export const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Authorization, Mcp-Session-Id, apikey, x-client-info",
+};
+
+export function createServiceClient() {
+  return createClient(
+    Deno.env.get("SUPABASE_URL")!,
+    Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!,
+  );
+}
+
+export function getOpenAIKey(): string {
+  const key = Deno.env.get("OPENAI_API_KEY");
+  if (!key) throw new Error("OPENAI_API_KEY secret not set on this project");
+  return key;
+}
+
+export function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, "Content-Type": "application/json" },
+  });
+}
+
+export function errorResponse(
+  id: unknown,
+  code: number,
+  message: string,
+): Response {
+  return jsonResponse(
+    {
+      jsonrpc: "2.0",
+      id: id ?? null,
+      error: { code, message },
+    },
+    200, // MCP errors are still HTTP 200 per spec; the error is in the payload
+  );
+}
+
+export function notificationResponse(): Response {
+  return new Response(null, {
+    status: 202,
+    headers: CORS_HEADERS,
+  });
+}

--- a/supabase/functions/cerefox/tools/audit-log.ts
+++ b/supabase/functions/cerefox/tools/audit-log.ts
@@ -1,0 +1,36 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+export interface AuditLogArgs {
+  document_id?: string;
+  author?: string;
+  operation?: string;
+  since?: string;
+  until?: string;
+  limit?: number;
+}
+
+export async function executeAuditLog(
+  supabase: SupabaseClient,
+  args: AuditLogArgs,
+): Promise<unknown[]> {
+  const params: Record<string, unknown> = {};
+  if (args.document_id) params.p_document_id = args.document_id;
+  if (args.author) params.p_author = args.author;
+  if (args.operation) params.p_operation = args.operation;
+  if (args.since) params.p_since = args.since;
+  if (args.until) params.p_until = args.until;
+  if (args.limit) params.p_limit = Math.min(Number(args.limit) || 50, 200);
+
+  const { data, error } = await supabase.rpc(
+    "cerefox_list_audit_entries",
+    params,
+  );
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+}

--- a/supabase/functions/cerefox/tools/get-document.ts
+++ b/supabase/functions/cerefox/tools/get-document.ts
@@ -1,0 +1,59 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+export interface GetDocumentArgs {
+  document_id: string;
+  version_id?: string | null;
+}
+
+export interface GetDocumentResult {
+  document_id: string;
+  doc_title: string;
+  full_content: string;
+  chunk_count: number;
+  total_chars: number;
+  is_archived: boolean;
+  version_id: string | null;
+}
+
+export async function executeGetDocument(
+  supabase: SupabaseClient,
+  args: GetDocumentArgs,
+): Promise<GetDocumentResult> {
+  const { document_id, version_id = null } = args;
+
+  if (!document_id) {
+    throw new Error("document_id is required");
+  }
+
+  const { data, error } = await supabase.rpc("cerefox_get_document", {
+    p_document_id: document_id,
+    p_version_id: version_id,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const row = data?.[0] as {
+    doc_title?: string;
+    full_content?: string;
+    chunk_count?: number;
+    total_chars?: number;
+  } | undefined;
+
+  if (!row) {
+    throw new Error("DOCUMENT_NOT_FOUND");
+  }
+
+  return {
+    document_id,
+    doc_title: row.doc_title ?? "Untitled",
+    full_content: row.full_content ?? "",
+    chunk_count: row.chunk_count ?? 0,
+    total_chars: row.total_chars ?? 0,
+    is_archived: version_id !== null,
+    version_id,
+  };
+}

--- a/supabase/functions/cerefox/tools/ingest.ts
+++ b/supabase/functions/cerefox/tools/ingest.ts
@@ -1,0 +1,417 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { embedTexts, OPENAI_MODEL } from "../embeddings.ts";
+
+const MAX_CHUNK_CHARS = 4000;
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+export interface IngestArgs {
+  title: string;
+  content: string;
+  project_name?: string;
+  source?: string;
+  metadata?: Record<string, unknown>;
+  update_if_exists?: boolean;
+  author?: string;
+  author_type?: string;
+}
+
+export interface IngestResult {
+  document_id: string;
+  title: string;
+  chunk_count?: number;
+  total_chars?: number;
+  skipped?: boolean;
+  updated?: boolean;
+  message?: string;
+  project_id?: string | null;
+  project_name?: string | null;
+}
+
+// ── Heading-aware chunker ────────────────────────────────────────────────
+
+interface Chunk {
+  heading_path: string[];
+  heading_level: number;
+  title: string;
+  content: string;
+  char_count: number;
+}
+
+interface Section {
+  level: number;
+  headings: string[];
+  heading: string;
+  content: string;
+  body: string;
+}
+
+function parseSections(text: string): Section[] {
+  const lines = text.split("\n");
+  const sections: Section[] = [];
+  let currentHeadings: string[] = [];
+  let currentLevel = 0;
+  let bodyLines: string[] = [];
+
+  function collectSection() {
+    const body = bodyLines.join("\n").trim();
+    bodyLines = [];
+    let content: string;
+    if (currentLevel > 0) {
+      const headerLine =
+        "#".repeat(currentLevel) +
+        " " +
+        (currentHeadings[currentHeadings.length - 1] ?? "");
+      content = body ? headerLine + "\n\n" + body : headerLine;
+    } else {
+      content = body;
+    }
+    if (!content.trim()) return;
+    sections.push({
+      level: currentLevel,
+      headings: [...currentHeadings],
+      heading: currentHeadings[currentHeadings.length - 1] ?? "",
+      content,
+      body,
+    });
+  }
+
+  for (const line of lines) {
+    const h1 = line.match(/^# (.+)/);
+    const h2 = line.match(/^## (.+)/);
+    const h3 = line.match(/^### (.+)/);
+
+    if (h1) {
+      collectSection();
+      currentHeadings = [h1[1].trim()];
+      currentLevel = 1;
+    } else if (h2) {
+      collectSection();
+      currentHeadings = [currentHeadings[0] ?? "", h2[1].trim()].filter(
+        Boolean,
+      );
+      currentLevel = 2;
+    } else if (h3) {
+      collectSection();
+      currentHeadings = [
+        currentHeadings[0] ?? "",
+        currentHeadings[1] ?? "",
+        h3[1].trim(),
+      ].filter(Boolean);
+      currentLevel = 3;
+    } else {
+      bodyLines.push(line);
+    }
+  }
+  collectSection();
+  return sections;
+}
+
+function makeChunk(
+  headings: string[],
+  level: number,
+  content: string,
+): Chunk {
+  const title = headings[headings.length - 1] ?? "";
+  return {
+    heading_path: [...headings],
+    heading_level: level,
+    title,
+    content,
+    char_count: content.length,
+  };
+}
+
+function chunkMarkdown(text: string): Chunk[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+
+  if (trimmed.length <= MAX_CHUNK_CHARS) {
+    return [makeChunk([], 0, trimmed)];
+  }
+
+  const sections = parseSections(trimmed);
+  const chunks: Chunk[] = [];
+
+  let bufParts: string[] = [];
+  let bufHeadings: string[] = [];
+  let bufLevel = 0;
+  let bufChars = 0;
+
+  function flushBuf() {
+    if (bufParts.length === 0) return;
+    chunks.push(makeChunk(bufHeadings, bufLevel, bufParts.join("\n\n")));
+    bufParts = [];
+    bufHeadings = [];
+    bufLevel = 0;
+    bufChars = 0;
+  }
+
+  for (const section of sections) {
+    const { level, headings, heading, content, body } = section;
+
+    if (content.length > MAX_CHUNK_CHARS) {
+      flushBuf();
+      const headerPrefix =
+        level > 0 ? "#".repeat(level) + " " + heading + "\n\n" : "";
+      const bodyToSplit = body || content;
+      const paragraphs = bodyToSplit.split(/\n\n+/);
+      let sub = "";
+      let isFirst = true;
+      for (const para of paragraphs) {
+        const prefix = isFirst ? headerPrefix : "";
+        if (
+          sub.length + prefix.length + para.length + 2 > MAX_CHUNK_CHARS &&
+          sub.length > 0
+        ) {
+          chunks.push(makeChunk(headings, level, sub.trim()));
+          sub = para;
+          isFirst = false;
+        } else {
+          sub = sub ? sub + "\n\n" + para : prefix + para;
+          isFirst = false;
+        }
+      }
+      if (sub.trim()) chunks.push(makeChunk(headings, level, sub.trim()));
+      continue;
+    }
+
+    const addition = content.length + (bufParts.length > 0 ? 2 : 0);
+
+    if (bufChars + addition <= MAX_CHUNK_CHARS) {
+      if (bufParts.length === 0) {
+        bufHeadings = headings;
+        bufLevel = level;
+      }
+      bufParts.push(content);
+      bufChars += addition;
+    } else {
+      flushBuf();
+      bufParts = [content];
+      bufHeadings = headings;
+      bufLevel = level;
+      bufChars = content.length;
+    }
+  }
+
+  flushBuf();
+  return chunks;
+}
+
+// ── Content normalisation + hash ─────────────────────────────────────────
+// Must stay in sync with pipeline.py::_normalize / _hash.
+
+function normalizeContent(text: string): string {
+  return text
+    .trim()
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+async function sha256hex(text: string): Promise<string> {
+  const bytes = new TextEncoder().encode(text);
+  const hash = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(hash))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+// ── Main execute function ────────────────────────────────────────────────
+
+export async function executeIngest(
+  supabase: SupabaseClient,
+  openaiKey: string,
+  args: IngestArgs,
+): Promise<IngestResult> {
+  const {
+    title,
+    content,
+    project_name,
+    source = "agent",
+    metadata = {},
+    update_if_exists = false,
+    author = "agent",
+    author_type = "agent",
+  } = args;
+
+  if (!title?.trim() || !content?.trim()) {
+    throw new Error("title and content are required");
+  }
+
+  const contentHash = await sha256hex(normalizeContent(content));
+
+  // ── Update-existing path ─────────────────────────────────────────────
+  if (update_if_exists) {
+    const { data: existing } = await supabase
+      .from("cerefox_documents")
+      .select("id, title, content_hash")
+      .eq("title", title.trim())
+      .order("updated_at", { ascending: false })
+      .limit(1);
+
+    if (existing?.length) {
+      const existingDoc = existing[0];
+
+      if (existingDoc.content_hash === contentHash) {
+        return {
+          document_id: existingDoc.id,
+          title: existingDoc.title,
+          skipped: true,
+          updated: false,
+          message: "Document already up-to-date (content hash match)",
+        };
+      }
+
+      const chunks = chunkMarkdown(content);
+      if (chunks.length === 0) {
+        throw new Error("Content produced no chunks");
+      }
+
+      const texts = chunks.map((c) => c.content);
+      const embeddings = await embedTexts(texts, openaiKey);
+
+      const totalChars = chunks.reduce((s, c) => s + c.char_count, 0);
+      const reviewStatus =
+        author_type === "agent" ? "pending_review" : "approved";
+
+      const chunkData = chunks.map((chunk, i) => ({
+        chunk_index: i,
+        heading_path: chunk.heading_path,
+        heading_level: chunk.heading_level,
+        title: chunk.title,
+        content: chunk.content,
+        char_count: chunk.char_count,
+        embedding: embeddings[i],
+        embedder: OPENAI_MODEL,
+      }));
+
+      const { error: ingestErr } = await supabase.rpc(
+        "cerefox_ingest_document",
+        {
+          p_document_id: existingDoc.id,
+          p_title: existingDoc.title,
+          p_source: source,
+          p_content_hash: contentHash,
+          p_metadata: metadata,
+          p_review_status: reviewStatus,
+          p_chunks: chunkData,
+          p_author: author,
+          p_author_type: author_type,
+          p_source_label: source,
+        },
+      );
+
+      if (ingestErr) {
+        throw new Error(`Ingest RPC failed: ${ingestErr.message}`);
+      }
+
+      return {
+        document_id: existingDoc.id,
+        title: existingDoc.title,
+        chunk_count: chunks.length,
+        total_chars: totalChars,
+        updated: true,
+      };
+    }
+    // No match found -- fall through to normal create below
+  }
+
+  // ── Hash deduplication (normal create path) ────────────────────────────
+  const { data: hashMatch } = await supabase
+    .from("cerefox_documents")
+    .select("id, title")
+    .eq("content_hash", contentHash)
+    .limit(1);
+
+  if (hashMatch?.length) {
+    return {
+      document_id: hashMatch[0].id,
+      title: hashMatch[0].title,
+      skipped: true,
+      message: "Document already exists (content hash match)",
+    };
+  }
+
+  // Chunk the content
+  const chunks = chunkMarkdown(content);
+  if (chunks.length === 0) {
+    throw new Error("Content produced no chunks");
+  }
+
+  // Embed all chunks
+  const texts = chunks.map((c) => c.content);
+  const embeddings = await embedTexts(texts, openaiKey);
+
+  const totalChars = chunks.reduce((s, c) => s + c.char_count, 0);
+  const reviewStatus = author_type === "agent" ? "pending_review" : "approved";
+
+  const chunkData = chunks.map((chunk, i) => ({
+    chunk_index: i,
+    heading_path: chunk.heading_path,
+    heading_level: chunk.heading_level,
+    title: chunk.title,
+    content: chunk.content,
+    char_count: chunk.char_count,
+    embedding: embeddings[i],
+    embedder: OPENAI_MODEL,
+  }));
+
+  const { data: ingestResult, error: ingestErr } = await supabase.rpc(
+    "cerefox_ingest_document",
+    {
+      p_document_id: null,
+      p_title: title.trim(),
+      p_source: source,
+      p_content_hash: contentHash,
+      p_metadata: metadata,
+      p_review_status: reviewStatus,
+      p_chunks: chunkData,
+      p_author: author,
+      p_author_type: author_type,
+    },
+  );
+
+  if (ingestErr || !ingestResult?.length) {
+    throw new Error(
+      `Ingest RPC failed: ${ingestErr?.message ?? "no data returned"}`,
+    );
+  }
+
+  const documentId = ingestResult[0].document_id;
+
+  // Resolve / create project if requested
+  let projectId: string | null = null;
+  if (project_name) {
+    const { data: proj } = await supabase
+      .from("cerefox_projects")
+      .select("id")
+      .ilike("name", project_name)
+      .limit(1);
+
+    if (proj?.length) {
+      projectId = proj[0].id;
+    } else {
+      const { data: newProj } = await supabase
+        .from("cerefox_projects")
+        .insert({ name: project_name })
+        .select("id");
+      projectId = newProj?.[0]?.id ?? null;
+    }
+
+    if (projectId) {
+      await supabase
+        .from("cerefox_document_projects")
+        .insert({ document_id: documentId, project_id: projectId });
+    }
+  }
+
+  return {
+    document_id: documentId,
+    title: title.trim(),
+    chunk_count: chunks.length,
+    total_chars: totalChars,
+    project_id: projectId,
+    project_name: project_name ?? null,
+  };
+}

--- a/supabase/functions/cerefox/tools/list-versions.ts
+++ b/supabase/functions/cerefox/tools/list-versions.ts
@@ -1,0 +1,27 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+export interface ListVersionsArgs {
+  document_id: string;
+}
+
+export async function executeListVersions(
+  supabase: SupabaseClient,
+  args: ListVersionsArgs,
+): Promise<unknown[]> {
+  if (!args.document_id) {
+    throw new Error("document_id is required");
+  }
+
+  const { data, error } = await supabase.rpc(
+    "cerefox_list_document_versions",
+    { p_document_id: args.document_id },
+  );
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+}

--- a/supabase/functions/cerefox/tools/metadata.ts
+++ b/supabase/functions/cerefox/tools/metadata.ts
@@ -1,0 +1,15 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+export async function executeMetadata(
+  supabase: SupabaseClient,
+): Promise<unknown[]> {
+  const { data, error } = await supabase.rpc("cerefox_list_metadata_keys");
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+}

--- a/supabase/functions/cerefox/tools/search.ts
+++ b/supabase/functions/cerefox/tools/search.ts
@@ -1,0 +1,174 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { embedTexts } from "../embeddings.ts";
+
+const MAX_BYTES = 200_000;
+
+type SupabaseClient = ReturnType<typeof createClient>;
+
+export interface SearchArgs {
+  query: string;
+  project_name?: string;
+  match_count?: number;
+  mode?: "hybrid" | "fts" | "docs";
+  alpha?: number;
+  min_score?: number;
+  metadata_filter?: Record<string, string> | null;
+  max_bytes?: number;
+}
+
+export interface SearchResult {
+  results: unknown[];
+  query: string;
+  mode: string;
+  match_count: number;
+  project_name: string | null;
+  metadata_filter: Record<string, string> | null;
+  truncated: boolean;
+  response_bytes: number;
+}
+
+async function lookupProjectId(
+  supabase: SupabaseClient,
+  projectName: string,
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from("cerefox_projects")
+    .select("id")
+    .ilike("name", projectName)
+    .limit(1);
+
+  if (error || !data?.length) return null;
+  return data[0].id;
+}
+
+function applyByteBudget(
+  rows: unknown[],
+  maxBytes: number,
+): { accepted: unknown[]; truncated: boolean; usedBytes: number } {
+  const accepted: unknown[] = [];
+  let usedBytes = 0;
+  let truncated = false;
+
+  for (const row of rows) {
+    const rowBytes = new TextEncoder().encode(JSON.stringify(row)).length;
+    if (usedBytes + rowBytes > maxBytes) {
+      truncated = true;
+      break;
+    }
+    accepted.push(row);
+    usedBytes += rowBytes;
+  }
+
+  return { accepted, truncated, usedBytes };
+}
+
+export async function executeSearch(
+  supabase: SupabaseClient,
+  openaiKey: string,
+  args: SearchArgs,
+): Promise<SearchResult> {
+  const {
+    query,
+    project_name,
+    match_count = 5,
+    mode = "docs",
+    alpha = 0.7,
+    min_score = 0.5,
+    metadata_filter = null,
+    max_bytes: requested_max_bytes,
+  } = args;
+
+  const max_bytes = Math.min(requested_max_bytes ?? MAX_BYTES, MAX_BYTES);
+
+  if (
+    metadata_filter !== null &&
+    metadata_filter !== undefined &&
+    (typeof metadata_filter !== "object" || Array.isArray(metadata_filter))
+  ) {
+    throw new Error("metadata_filter must be a JSON object or null");
+  }
+
+  if (!query || typeof query !== "string" || !query.trim()) {
+    throw new Error("query is required");
+  }
+
+  // Resolve project name -> UUID if provided
+  let projectId: string | null = null;
+  if (project_name) {
+    projectId = await lookupProjectId(supabase, project_name);
+    if (!projectId) {
+      throw new Error(`Project not found: ${project_name}`);
+    }
+  }
+
+  // FTS mode doesn't need an embedding
+  let embedding: number[] | null = null;
+  if (mode !== "fts") {
+    const embeddings = await embedTexts(query, openaiKey);
+    embedding = embeddings[0];
+  }
+
+  // Call the appropriate RPC
+  let rpcName: string;
+  let rpcParams: Record<string, unknown>;
+
+  const metaFilterParam =
+    metadata_filter && Object.keys(metadata_filter).length > 0
+      ? { p_metadata_filter: metadata_filter }
+      : {};
+
+  if (mode === "fts") {
+    rpcName = "cerefox_fts_search";
+    rpcParams = {
+      p_query_text: query,
+      p_match_count: match_count,
+      p_project_id: projectId,
+      ...metaFilterParam,
+    };
+  } else if (mode === "hybrid") {
+    rpcName = "cerefox_hybrid_search";
+    rpcParams = {
+      p_query_text: query,
+      p_query_embedding: embedding,
+      p_match_count: match_count,
+      p_alpha: alpha,
+      p_use_upgrade: false,
+      p_project_id: projectId,
+      p_min_score: min_score,
+      ...metaFilterParam,
+    };
+  } else {
+    rpcName = "cerefox_search_docs";
+    rpcParams = {
+      p_query_text: query,
+      p_query_embedding: embedding,
+      p_match_count: match_count,
+      p_alpha: alpha,
+      p_project_id: projectId,
+      p_min_score: min_score,
+      ...metaFilterParam,
+    };
+  }
+
+  const { data, error } = await supabase.rpc(rpcName, rpcParams);
+
+  if (error) {
+    throw new Error(`RPC error: ${error.message}`);
+  }
+
+  const { accepted, truncated, usedBytes } = applyByteBudget(
+    data ?? [],
+    max_bytes,
+  );
+
+  return {
+    results: accepted,
+    query,
+    mode,
+    match_count,
+    project_name: project_name ?? null,
+    metadata_filter: metadata_filter ?? null,
+    truncated,
+    response_bytes: usedBytes,
+  };
+}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -127,14 +127,52 @@ class EdgeFunctionClient:
         return resp.json()
 
 
-@pytest.fixture(scope="session")
-def e2e_edge(e2e_settings: Settings) -> EdgeFunctionClient | None:
-    """An Edge Function client using the anon key for JWT auth.
+class McpEdgeFunctionClient:
+    """Invokes MCP tools on the consolidated cerefox edge function via JSON-RPC 2.0.
 
-    Returns None (and tests skip) if no valid JWT key is available.
-    Reads CEREFOX_SUPABASE_ANON_KEY from .env (via dotenv) or os env,
-    falling back to CEREFOX_SUPABASE_KEY if it looks like a JWT.
+    Sends standard MCP tools/call requests to /functions/v1/cerefox and returns
+    the result payload. Used for testing the consolidated edge function that
+    handles all tool logic inline (no internal fetch delegation).
     """
+
+    def __init__(self, base_url: str, anon_key: str) -> None:
+        self._http = httpx.Client(
+            base_url=f"{base_url}/functions/v1",
+            headers={
+                "Authorization": f"Bearer {anon_key}",
+                "Content-Type": "application/json",
+            },
+            timeout=30.0,
+        )
+        self._id_counter = 0
+
+    def call_tool(self, tool_name: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Send a tools/call JSON-RPC request, return the MCP result object.
+
+        Returns the 'result' field from the JSON-RPC response, which contains
+        'content': [{'type': 'text', 'text': '...'}].
+        """
+        self._id_counter += 1
+        resp = self._http.post("/cerefox", json={
+            "jsonrpc": "2.0",
+            "id": self._id_counter,
+            "method": "tools/call",
+            "params": {"name": tool_name, "arguments": arguments or {}},
+        })
+        resp.raise_for_status()
+        data = resp.json()
+        if "error" in data:
+            raise RuntimeError(f"MCP error: {data['error']}")
+        return data["result"]
+
+    def get_text(self, tool_name: str, arguments: dict[str, Any] | None = None) -> str:
+        """Call a tool and return the text content from the first content block."""
+        result = self.call_tool(tool_name, arguments)
+        return result["content"][0]["text"]
+
+
+def _resolve_anon_key(e2e_settings: Settings) -> str | None:
+    """Resolve the Supabase anon key from env vars or .env file."""
     from dotenv import dotenv_values
 
     dotenv = dotenv_values(".env")
@@ -145,9 +183,33 @@ def e2e_edge(e2e_settings: Settings) -> EdgeFunctionClient | None:
         main_key = e2e_settings.supabase_key
         if main_key.startswith("eyJ"):
             anon_key = main_key
+    return anon_key or None
+
+
+@pytest.fixture(scope="session")
+def e2e_edge(e2e_settings: Settings) -> EdgeFunctionClient | None:
+    """An Edge Function client using the anon key for JWT auth.
+
+    Returns None (and tests skip) if no valid JWT key is available.
+    Reads CEREFOX_SUPABASE_ANON_KEY from .env (via dotenv) or os env,
+    falling back to CEREFOX_SUPABASE_KEY if it looks like a JWT.
+    """
+    anon_key = _resolve_anon_key(e2e_settings)
     if not anon_key:
         return None
     return EdgeFunctionClient(e2e_settings.supabase_url, anon_key)
+
+
+@pytest.fixture(scope="session")
+def e2e_mcp_edge(e2e_settings: Settings) -> McpEdgeFunctionClient | None:
+    """An MCP Edge Function client for the consolidated cerefox function.
+
+    Uses the same anon key resolution as e2e_edge. Returns None if no key.
+    """
+    anon_key = _resolve_anon_key(e2e_settings)
+    if not anon_key:
+        return None
+    return McpEdgeFunctionClient(e2e_settings.supabase_url, anon_key)
 
 
 class E2ECleanup:

--- a/tests/e2e/test_consolidated_e2e.py
+++ b/tests/e2e/test_consolidated_e2e.py
@@ -1,0 +1,326 @@
+"""E2E tests for the consolidated cerefox edge function (MCP JSON-RPC 2.0).
+
+These tests target the consolidated /functions/v1/cerefox endpoint which handles
+all tool logic inline (no internal fetch delegation). All data seeding is done
+via MCP ingest (server-side embeddings) so no local OpenAI key is needed.
+
+Run with: uv run pytest tests/e2e/test_consolidated_e2e.py -m e2e -v
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from cerefox.db.client import CerefoxClient
+
+from .conftest import E2ECleanup, McpEdgeFunctionClient
+
+pytestmark = pytest.mark.e2e
+
+
+def _extract_doc_id(text: str) -> str:
+    """Extract document_id from MCP ingest response text."""
+    match = re.search(r"\(id:\s*([0-9a-f-]+)\)", text)
+    assert match, f"Could not extract document_id from: {text}"
+    return match.group(1)
+
+
+def _ingest_via_mcp(
+    mcp: McpEdgeFunctionClient,
+    title: str,
+    content: str,
+    metadata: dict | None = None,
+    update_if_exists: bool = False,
+) -> tuple[str, str]:
+    """Ingest a document via MCP and return (doc_id, response_text)."""
+    args: dict = {"title": title, "content": content}
+    if metadata:
+        args["metadata"] = metadata
+    if update_if_exists:
+        args["update_if_exists"] = True
+    text = mcp.get_text("cerefox_ingest", args)
+    doc_id = _extract_doc_id(text)
+    return doc_id, text
+
+
+# ── 1. Ingest tests ──────────────────────────────────────────────────────────
+
+
+class TestConsolidatedIngest:
+    """Ingest, dedup, and update via the consolidated MCP endpoint."""
+
+    def test_ingest_and_dedup(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+        e2e_client: CerefoxClient,
+        cleanup: E2ECleanup,
+        unique_title,
+    ):
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        title = unique_title("MCP Ingest Test")
+        content = "# MCP Ingest\n\nThis document was ingested via the consolidated MCP function."
+        metadata = {"source_test": "e2e-mcp", "layer": "consolidated"}
+
+        # Ingest via MCP
+        doc_id, text = _ingest_via_mcp(e2e_mcp_edge, title, content, metadata)
+        cleanup.track_document(doc_id)
+        assert "Document saved:" in text, f"Unexpected response: {text}"
+
+        # Verify doc exists in DB
+        doc = e2e_client.get_document_by_id(doc_id)
+        assert doc is not None
+        assert doc["title"] == title
+        assert doc["metadata"]["source_test"] == "e2e-mcp"
+
+        # Dedup — same content, different title
+        text2 = e2e_mcp_edge.get_text("cerefox_ingest", {
+            "title": unique_title("MCP Ingest Dedup"),
+            "content": content,
+        })
+        assert "already" in text2.lower(), f"Expected dedup skip, got: {text2}"
+
+        # Update — different content, same title, update_if_exists=true
+        updated_content = content + "\n\n## Update\n\nAdded by MCP e2e test."
+        text3 = e2e_mcp_edge.get_text("cerefox_ingest", {
+            "title": title,
+            "content": updated_content,
+            "update_if_exists": True,
+        })
+        assert "updated" in text3.lower() or "Document updated:" in text3, (
+            f"Expected update confirmation, got: {text3}"
+        )
+
+
+# ── 2. Search tests ──────────────────────────────────────────────────────────
+
+
+class TestConsolidatedSearch:
+    """Search via the consolidated MCP endpoint. Data seeded via MCP ingest."""
+
+    def test_search(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+        cleanup: E2ECleanup,
+        unique_title,
+    ):
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        title = unique_title("MCP Search Target")
+        content = (
+            "# Quantum Harmonic Oscillator\n\n"
+            "The quantum harmonic oscillator describes vibrational modes "
+            "of diatomic molecules and crystal lattice phonons."
+        )
+
+        # Seed data via MCP ingest (server-side embeddings)
+        doc_id, _ = _ingest_via_mcp(e2e_mcp_edge, title, content)
+        cleanup.track_document(doc_id)
+
+        time.sleep(1)
+
+        # Search via MCP
+        text = e2e_mcp_edge.get_text("cerefox_search", {
+            "query": "quantum harmonic oscillator",
+            "match_count": 10,
+        })
+        assert "No results found" not in text, f"Search returned no results: {text}"
+        assert "Quantum Harmonic Oscillator" in text, (
+            f"Expected to find ingested doc in results: {text[:500]}"
+        )
+
+
+# ── 3. Metadata tests ────────────────────────────────────────────────────────
+
+
+class TestConsolidatedMetadata:
+    """Metadata listing via the consolidated MCP endpoint."""
+
+    def test_list_metadata_keys(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+        cleanup: E2ECleanup,
+        unique_title,
+    ):
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        # Seed data via MCP ingest
+        title = unique_title("MCP Metadata Test")
+        doc_id, _ = _ingest_via_mcp(
+            e2e_mcp_edge, title,
+            "# Metadata Test\n\nDocument for testing MCP metadata key discovery.",
+            metadata={"e2e_mcp_tag": "mcp-metadata-test"},
+        )
+        cleanup.track_document(doc_id)
+
+        # List metadata keys via MCP
+        text = e2e_mcp_edge.get_text("cerefox_list_metadata_keys", {})
+        assert "e2e_mcp_tag" in text, f"Expected 'e2e_mcp_tag' in metadata keys: {text[:500]}"
+
+
+# ── 4. Metadata-filtered search ──────────────────────────────────────────────
+
+
+class TestConsolidatedMetadataFilter:
+    """Metadata filter via the consolidated MCP endpoint."""
+
+    def test_metadata_filter(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+        cleanup: E2ECleanup,
+        unique_title,
+    ):
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        title_a = unique_title("MCP MetaFilter A")
+        title_b = unique_title("MCP MetaFilter B")
+
+        # Seed both docs via MCP ingest
+        doc_id_a, _ = _ingest_via_mcp(
+            e2e_mcp_edge, title_a,
+            "# MCP Filter A\n\nDecision document for consolidated function filter test.",
+            metadata={"e2e_mcp_type": "decision"},
+        )
+        doc_id_b, _ = _ingest_via_mcp(
+            e2e_mcp_edge, title_b,
+            "# MCP Filter B\n\nNote document for consolidated function filter test.",
+            metadata={"e2e_mcp_type": "note"},
+        )
+        cleanup.track_document(doc_id_a)
+        cleanup.track_document(doc_id_b)
+        time.sleep(2)
+
+        # Search with metadata filter via MCP
+        text = e2e_mcp_edge.get_text("cerefox_search", {
+            "query": "consolidated function filter test",
+            "match_count": 10,
+            "metadata_filter": {"e2e_mcp_type": "decision"},
+        })
+        assert "MCP Filter A" in text, f"Decision doc should appear in filtered results: {text[:500]}"
+        assert "MCP Filter B" not in text, f"Note doc should be excluded by filter: {text[:500]}"
+
+
+# ── 5. Get document test ─────────────────────────────────────────────────────
+
+
+class TestConsolidatedGetDocument:
+    """Get document via the consolidated MCP endpoint."""
+
+    def test_get_document(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+        cleanup: E2ECleanup,
+        unique_title,
+    ):
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        title = unique_title("MCP GetDoc Test")
+        content = "# Get Document Test\n\nContent for testing document retrieval via MCP."
+
+        # Seed via MCP ingest
+        doc_id, _ = _ingest_via_mcp(e2e_mcp_edge, title, content)
+        cleanup.track_document(doc_id)
+
+        # Retrieve via MCP
+        text = e2e_mcp_edge.get_text("cerefox_get_document", {
+            "document_id": doc_id,
+        })
+        assert title in text, f"Expected title in retrieved document: {text[:500]}"
+        assert "Get Document Test" in text, f"Expected heading in content: {text[:500]}"
+        assert "(current)" in text, f"Expected (current) label: {text[:200]}"
+
+    def test_get_document_not_found(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+    ):
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        text = e2e_mcp_edge.get_text("cerefox_get_document", {
+            "document_id": "00000000-0000-0000-0000-000000000000",
+        })
+        assert "not found" in text.lower(), f"Expected 'not found', got: {text}"
+
+
+# ── 6. MCP protocol tests ────────────────────────────────────────────────────
+
+
+class TestConsolidatedMcpProtocol:
+    """Verify the MCP protocol layer of the consolidated function."""
+
+    def test_initialize(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+    ):
+        """The initialize method should return protocol version and capabilities."""
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        e2e_mcp_edge._id_counter += 1
+        resp = e2e_mcp_edge._http.post("/cerefox", json={
+            "jsonrpc": "2.0",
+            "id": e2e_mcp_edge._id_counter,
+            "method": "initialize",
+            "params": {},
+        })
+        resp.raise_for_status()
+        data = resp.json()
+        assert data["result"]["protocolVersion"] == "2025-03-26"
+        assert data["result"]["serverInfo"]["name"] == "cerefox"
+        assert "tools" in data["result"]["capabilities"]
+
+    def test_tools_list(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+    ):
+        """The tools/list method should return all 6 tool definitions."""
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        e2e_mcp_edge._id_counter += 1
+        resp = e2e_mcp_edge._http.post("/cerefox", json={
+            "jsonrpc": "2.0",
+            "id": e2e_mcp_edge._id_counter,
+            "method": "tools/list",
+            "params": {},
+        })
+        resp.raise_for_status()
+        data = resp.json()
+        tools = data["result"]["tools"]
+        tool_names = {t["name"] for t in tools}
+        expected = {
+            "cerefox_search",
+            "cerefox_ingest",
+            "cerefox_list_metadata_keys",
+            "cerefox_get_document",
+            "cerefox_list_versions",
+            "cerefox_get_audit_log",
+        }
+        assert tool_names == expected, f"Expected {expected}, got {tool_names}"
+
+    def test_unknown_tool_returns_error(
+        self,
+        e2e_mcp_edge: McpEdgeFunctionClient | None,
+    ):
+        """Calling an unknown tool should return a JSON-RPC error, not crash."""
+        if e2e_mcp_edge is None:
+            pytest.skip("No JWT key for MCP Edge Function (set CEREFOX_SUPABASE_ANON_KEY)")
+
+        e2e_mcp_edge._id_counter += 1
+        resp = e2e_mcp_edge._http.post("/cerefox", json={
+            "jsonrpc": "2.0",
+            "id": e2e_mcp_edge._id_counter,
+            "method": "tools/call",
+            "params": {"name": "nonexistent_tool", "arguments": {}},
+        })
+        resp.raise_for_status()
+        data = resp.json()
+        assert "error" in data, f"Expected error for unknown tool, got: {data}"


### PR DESCRIPTION
## Summary

Closes #1

- Adds new `supabase/functions/cerefox/` edge function that handles MCP protocol + all tool logic inline (search, ingest, get-document, list-versions, audit-log, metadata)
- Eliminates the gateway-to-worker `fetch()` hop that doubled Supabase edge function invocations per MCP call (2 → 1)
- Existing functions untouched — additive change for side-by-side comparison
- Adds parallel e2e test suite (`test_consolidated_e2e.py`) with MCP JSON-RPC client

## Architecture

**Before:** `cerefox-mcp` → `fetch()` → `cerefox-search` (2 invocations)
**After:** `cerefox` handles everything inline (1 invocation)

## Files added

**Consolidated function** (`supabase/functions/cerefox/`):
- `index.ts` — MCP protocol + tool dispatch
- `shared.ts` — CORS, Supabase client, response helpers
- `embeddings.ts` — Unified OpenAI embedding (search + ingest)
- `tools/` — search, ingest, get-document, list-versions, audit-log, metadata

**Tests** (`tests/e2e/`):
- `conftest.py` — added `McpEdgeFunctionClient` + `e2e_mcp_edge` fixture
- `test_consolidated_e2e.py` — 10 test cases covering all tools + MCP protocol

## Test plan

- [ ] Deploy `cerefox` function to Supabase
- [ ] Run `uv run pytest tests/e2e/test_consolidated_e2e.py -m e2e -v`
- [ ] Verify existing tests still pass: `uv run pytest -m e2e`
- [ ] Check Supabase dashboard: 1 invocation per MCP call (not 2)
- [ ] Point Claude Code at new URL and verify all tools work