### PR TITLE
Add hub_search tool for historical message lookup

### DIFF
--- a/supabase/functions/message-hub-mcp/index.ts
+++ b/supabase/functions/message-hub-mcp/index.ts
@@ -82,6 +82,21 @@ const TOOLS = [
     },
   },
   {
+    name: "hub_search",
+    description: "Search hub message history (read and unread).",
+    inputSchema: {
+      type: "object",
+      required: ["conclave", "since"],
+      properties: {
+        conclave: { type: "string", description: "Conclave name to search (e.g., 'personal')" },
+        since: { type: "string", description: "Date or datetime — return messages after this (e.g., '2026-03-25' or '2026-03-25T14:00:00Z')" },
+        from_conclave: { type: "string", description: "Filter by sender conclave (optional)" },
+        from_agent: { type: "string", description: "Filter by sender agent (optional)" },
+        include_broadcast: { type: "boolean", description: "Include messages addressed to 'all' (default: true)" },
+      },
+    },
+  },
+  {
     name: "hub_mark_read",
     description: "Mark a hub message as received/processed.",
     inputSchema: {
@@ -156,6 +171,56 @@ async function handlePoll(args: Record<string, unknown>): Promise<string> {
   return `${messages.length} unread message(s):\n\n${lines.join("\n\n---\n\n")}`;
 }
 
+async function handleSearch(args: Record<string, unknown>): Promise<string> {
+  const supabase = makeSupabaseClient();
+  const conclave = args.conclave as string;
+  const since = args.since as string;
+  const fromConclave = args.from_conclave as string | undefined;
+  const fromAgent = args.from_agent as string | undefined;
+  const includeBroadcast = args.include_broadcast !== false;
+
+  let query = supabase
+    .from("hub_messages")
+    .select("*")
+    .gt("created_at", since)
+    .order("created_at", { ascending: false });
+
+  if (includeBroadcast) {
+    query = query.or(`to_conclave.eq.${conclave},to_conclave.eq.all`);
+  } else {
+    query = query.eq("to_conclave", conclave);
+  }
+
+  if (fromConclave) {
+    query = query.eq("from_conclave", fromConclave);
+  }
+  if (fromAgent) {
+    query = query.eq("from_agent", fromAgent);
+  }
+
+  const { data, error } = await query;
+
+  if (error) throw new Error(`Query error: ${error.message}`);
+
+  const messages = data ?? [];
+
+  if (messages.length === 0) {
+    return "No messages found.";
+  }
+
+  const lines = messages.map((m: Record<string, unknown>) => {
+    const status = m.received_at ? `read by ${m.received_by} at ${m.received_at}` : "unread";
+    return (
+      `## ${m.subject}\n` +
+      `**From:** ${m.from_conclave}:${m.from_agent} | **To:** ${m.to_conclave}:${m.to_agent} | **ID:** ${m.id}\n` +
+      `**Sent:** ${m.created_at} | **Status:** ${status}\n\n` +
+      `${m.body}`
+    );
+  });
+
+  return `${messages.length} message(s):\n\n${lines.join("\n\n---\n\n")}`;
+}
+
 async function handleMarkRead(args: Record<string, unknown>): Promise<string> {
   const supabase = makeSupabaseClient();
 
@@ -178,6 +243,7 @@ async function dispatchTool(name: string, args: Record<string, unknown>): Promis
   switch (name) {
     case "hub_send": return await handleSend(args);
     case "hub_poll": return await handlePoll(args);
+    case "hub_search": return await handleSearch(args);
     case "hub_mark_read": return await handleMarkRead(args);
     default: throw new Error(`Unknown tool: ${name}`);
   }

--- a/tests/e2e/test_message_hub_e2e.py
+++ b/tests/e2e/test_message_hub_e2e.py
@@ -127,7 +127,7 @@ def test_tools_list(hub_client: HubMCPClient) -> None:
     resp = hub_client.call("tools/list")
     tools = resp["result"]["tools"]
     names = [t["name"] for t in tools]
-    assert sorted(names) == ["hub_mark_read", "hub_poll", "hub_send"]
+    assert sorted(names) == ["hub_mark_read", "hub_poll", "hub_search", "hub_send"]
 
 
 def test_get_returns_405(hub_client: HubMCPClient) -> None:
@@ -243,3 +243,77 @@ def test_poll_broadcast(hub_client: HubMCPClient) -> None:
         "include_broadcast": False,
     })
     assert subject not in poll_text_no_bc
+
+
+def test_search_includes_read_messages(hub_client: HubMCPClient) -> None:
+    """hub_search returns messages even after they are marked read."""
+    subject = _unique_subject("search-read")
+    since_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    # Send and mark read
+    send_text = hub_client.tool_text("hub_send", {
+        "from_conclave": "test",
+        "from_agent": "steward",
+        "to_conclave": "test-search",
+        "subject": subject,
+        "body": "Search me after read",
+    })
+    msg_id = send_text.split("id: ")[1].strip(")")
+
+    hub_client.tool_text("hub_mark_read", {
+        "message_id": msg_id,
+        "receiver": "test-search:archivist",
+    })
+
+    # hub_poll should NOT find it (already read)
+    poll_text = hub_client.tool_text("hub_poll", {"conclave": "test-search"})
+    assert subject not in poll_text
+
+    # hub_search SHOULD find it
+    search_text = hub_client.tool_text("hub_search", {
+        "conclave": "test-search",
+        "since": since_ts,
+    })
+    assert subject in search_text
+    assert "read by" in search_text
+
+
+def test_search_with_sender_filters(hub_client: HubMCPClient) -> None:
+    """hub_search filters by from_conclave and from_agent."""
+    subject_a = _unique_subject("search-filter-a")
+    subject_b = _unique_subject("search-filter-b")
+    since_ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    # Send from two different senders
+    hub_client.tool_text("hub_send", {
+        "from_conclave": "alpha",
+        "from_agent": "steward",
+        "to_conclave": "test-search-filter",
+        "subject": subject_a,
+        "body": "From alpha",
+    })
+    hub_client.tool_text("hub_send", {
+        "from_conclave": "beta",
+        "from_agent": "archivist",
+        "to_conclave": "test-search-filter",
+        "subject": subject_b,
+        "body": "From beta",
+    })
+
+    # Search filtered by from_conclave
+    search_text = hub_client.tool_text("hub_search", {
+        "conclave": "test-search-filter",
+        "since": since_ts,
+        "from_conclave": "alpha",
+    })
+    assert subject_a in search_text
+    assert subject_b not in search_text
+
+    # Search filtered by from_agent
+    search_text = hub_client.tool_text("hub_search", {
+        "conclave": "test-search-filter",
+        "since": since_ts,
+        "from_agent": "archivist",
+    })
+    assert subject_b in search_text
+    assert subject_a not in search_text


### PR DESCRIPTION
## Summary
- Adds `hub_search` tool to `message-hub-mcp` edge function for querying message history (read and unread)
- Parameters: `conclave` (required), `since` (required, date or datetime), `from_conclave`, `from_agent`, `include_broadcast`
- Separates two use cases: `hub_poll` for operational "what's unread?" vs `hub_search` for "what happened since X?"
- 2 new e2e tests (search includes read messages, sender filters), all 9 passing

## Test plan
- [x] All 9 e2e tests passing (`pytest -m e2e tests/e2e/test_message_hub_e2e.py`)
- [x] Edge function deployed and verified
- [ ] Manual test via MCP: `hub_search(conclave="personal", since="2026-03-01")`

Closes #12